### PR TITLE
update lists: add Simplex Chat

### DIFF
--- a/src/Russia-domains-inside.lst
+++ b/src/Russia-domains-inside.lst
@@ -502,6 +502,13 @@ riotpixels.com
 threema.ch
 signal.org
 
+# SimpleX Chat
+simplex.chat
+simplex.im
+smp1.adminforge.de
+smp2.adminforge.de
+smp3.adminforge.de
+
 # Other
 saverudata.net
 mail-api.proton.me


### PR DESCRIPTION
Вместе с Threema был заблокирован и другой e2ee чат - Simplex Chat.
`simplex.chat` - официальный сайт.
На поддоменах `simplex.im` находятся официальные серверы.
`smp*.adminforge.de` - популярные сервера, тоже попавшие под блокировку.
