### PR TITLE
teamviewer.com added to Russia-domains-inside.lst

### DIFF
--- a/src/Russia-domains-inside.lst
+++ b/src/Russia-domains-inside.lst
@@ -407,6 +407,7 @@ smartdeploy.com
 
 # Programs
 zbigz.com
+teamviewer.com
 
 # AI
 remove.bg


### PR DESCRIPTION
Downloading teamviewer from Russia is restricted:
> TeamViewer does not provide sales, service, or support of any kind to countries that would cause TeamViewer to violate the export provisions of the European Union or the United States or if this is in any way prohibited in accordance with the Common Foreign and Security Policy of the EU or with U.S. export law.