### PR TITLE
Add Flourish to Russia-domains-inside.lst

### DIFF
--- a/src/Russia-domains-inside.lst
+++ b/src/Russia-domains-inside.lst
@@ -418,6 +418,8 @@ mongodb.com
 zbigz.com
 teamviewer.com
 notepad-plus-plus.org
+app.flourish.studio
+flourish.studio
 
 # AI
 remove.bg


### PR DESCRIPTION
Added `flourish.studio` and `app.flourish.studio` domains to Russia Inside list.

Reason:

<img width="991" alt="Снимок экрана 2024-12-10 в 02 27 07" src="https://github.com/user-attachments/assets/f9e0173d-439d-4929-87e8-dae497d8027f">
