### PR TITLE
Remove an extra '/'

### DIFF
--- a/Russia/inside-raw.lst
+++ b/Russia/inside-raw.lst
@@ -471,7 +471,7 @@ libgen.rs
 lidarr.audio
 lifehacker.com
 liga.net
-lightning.ai/
+lightning.ai
 linear.app
 linkedin.com
 linktr.ee


### PR DESCRIPTION
В коммите удалил лишний слэш, после домена lightning.ai в файле inside-raw.lst
Никакие домены в этом файле не содержат слэшей и этот случай являлся уникальным. Могут ломаться парсеры/конфиги, основанные на этом файле.