### PR TITLE
Added robinfrontend-pa.googleapis.com to google_ai.lst

### DIFF
--- a/Services/google_ai.lst
+++ b/Services/google_ai.lst
@@ -18,3 +18,4 @@ jules.google.com
 labs.google
 aisandbox-pa.googleapis.com
 stitch.withgoogle.com
+robinfrontend-pa.googleapis.com


### PR DESCRIPTION
Этот домен используется в Android приложении Google для Gemini