### PR TITLE
Add Qualcomm websites to geoblock

### DIFF
--- a/Categories/geoblock.lst
+++ b/Categories/geoblock.lst
@@ -413,3 +413,5 @@ netacad.com
 transferwise.com
 wise.com
 mouser.com
+
+qualcomm.com


### PR DESCRIPTION
Qualcomm блокирует доступ пользователям из РФ на многих своих ресурсах.