### PR TITLE
Remove gql.twitch.tv from Geoblock

### DIFF
--- a/Categories/geoblock.lst
+++ b/Categories/geoblock.lst
@@ -113,7 +113,6 @@ canva.com
 kaleido.ai
 
 usher.ttvnw.net
-gql.twitch.tv
 
 parallels.com
 myparallels.com


### PR DESCRIPTION
Домен `gql.twitch.tv` ни коим образом не отвечает, ни за качество видеопотока, ни за отображаемую в UI информацию о качестве.

Все возможные HLS плейлисты, разбитые по качеству, передаются **только** в мастер-плейлисте который берется с `usher.ttvnw.net`. Информация на клиенте парсится также самим плеером исходя из полученого мастер-плейлиста.

Я уже молчу, что данный домен в списке на проксацмю натурально вредит если туннель работает нестабильно: обращение к `gql` происходит каждую секунду и в случае провала трансляция просто зависает