### PR TITLE
Fix Gemini in some conditions

### DIFF
--- a/Services/google_ai.lst
+++ b/Services/google_ai.lst
@@ -19,3 +19,4 @@ labs.google
 aisandbox-pa.googleapis.com
 stitch.withgoogle.com
 robinfrontend-pa.googleapis.com
+speechs3proto2-pa.googleapis.com


### PR DESCRIPTION
В некоторых ситуациях Gemini отказывается работать без домена
```
speechs3proto2-pa.googleapis.com
```

Подробнее [на ntc.party](https://ntc.party/t/%D0%BE%D0%B1%D1%85%D0%BE%D0%B4-%D0%BE%D0%B3%D1%80%D0%B0%D0%BD%D0%B8%D1%87%D0%B5%D0%BD%D0%B8%D1%8F-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D0%BF%D1%80%D0%B8%D0%BB%D0%BE%D0%B6%D0%B5%D0%BD%D0%B8%D1%8F-google-gemini/13082/9)